### PR TITLE
Feat: skel support (binary)

### DIFF
--- a/src/components/SpineLoader/DropZone/index.tsx
+++ b/src/components/SpineLoader/DropZone/index.tsx
@@ -11,6 +11,10 @@ const missingFiles = (files: FileEntry[]): string[] => {
 			name: "json"
 		},
 		{
+			extensions: ["skel"],
+			name: "skel"
+		},
+		{
 			extensions: ["atlas"],
 			name: "atlas"
 		},
@@ -80,6 +84,9 @@ const DropZone: React.FC<DropZoneProps> = (props) => {
 					case "json":
 						reader.readAsText(file);
 						break;
+                    case 'skel':
+                        reader.readAsArrayBuffer(file);
+                        break;
 					case "atlas":
 						reader.readAsText(file);
 						break;

--- a/src/components/SpineLoader/DropZone/index.tsx
+++ b/src/components/SpineLoader/DropZone/index.tsx
@@ -7,12 +7,8 @@ import "./DropZone.css";
 const missingFiles = (files: FileEntry[]): string[] => {
 	const expectedTypes = [
 		{
-			extensions: ["json"],
-			name: "json"
-		},
-		{
-			extensions: ["skel"],
-			name: "skel"
+			extensions: ["json", "skel"],
+			name: "json | skel"
 		},
 		{
 			extensions: ["atlas"],

--- a/src/services/PixiService.ts
+++ b/src/services/PixiService.ts
@@ -7,7 +7,8 @@ import {
     ClippingAttachment,
     SkeletonBounds,
     PathAttachment,
-    Spine
+    Spine,
+    SkeletonBinary,
 } from "@pixi-spine/all-3.8";
 
 import {
@@ -248,8 +249,9 @@ class PixiService {
 
         const files = filesLoadedData.files;
         const rawJson = files.find((file) => file.type === "json")?.data;
+        const rawSkeleton = files.find((file) => file.type === "skel")?.data as ArrayBuffer;
         const rawAtlas = files.find((file) => file.type === "atlas")?.data;
-        const rawSkeletonData = JSON.parse(rawJson as string);
+        const rawSkeletonData = !!rawSkeleton ? new Uint8Array(rawSkeleton) :JSON.parse(rawJson as string);
         const spineAtlas = new TextureAtlas(rawAtlas as string, function (
             line,
             callback
@@ -262,7 +264,7 @@ class PixiService {
         const spineAtlasLoader = new AtlasAttachmentLoader(
             spineAtlas
         );
-        const spineJsonParser = new SkeletonJson(spineAtlasLoader);
+        const spineJsonParser = new (!!rawSkeleton ? SkeletonBinary: SkeletonJson)(spineAtlasLoader);
         const spineData = spineJsonParser.readSkeletonData(rawSkeletonData);
         this.spine = new Spine(spineData);
 


### PR DESCRIPTION
- Spine may export with binary format only (.skel). So just add support.
Just provide sample code. Please update it if you want it match to your style/format.